### PR TITLE
[codex] Add npm computer-use-cache package source

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,23 @@
+# Upstream provider. OpenRouter-compatible by default.
+UPSTREAM_BASE_URL=https://openrouter.ai/api/v1
+UPSTREAM_API_KEY=sk-or-v1-your-key-here
+
+# Server.
+HOST=0.0.0.0
+PORT=8000
+
+# Cache.
+CACHE_DB_PATH=./code_model_cache.sqlite3
+CACHE_ENABLED=1
+CACHE_TTL_SECONDS=2592000
+CACHE_MAX_INPUT_CHARS=120000
+CACHE_MAX_RESPONSE_CHARS=240000
+
+# Optional: cache only code/coding models. Supports shell-style wildcards.
+# CACHE_MODEL_ALLOWLIST=*coder*,*code*,openai/gpt-4.1*,anthropic/claude-*
+
+# Optional: require this token for POST /cache/clear.
+# CACHE_ADMIN_TOKEN=replace-me
+
+# Optional: add a code_model_cache object to JSON responses.
+INCLUDE_CACHE_METADATA=0

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+.computer-use-cache/
+.npm-cache/
+node_modules/
+npm-debug.log*
+computer-use-cache-*.tgz
+*.sqlite3
+*.db

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
   <a href="https://discord.gg/supers"><img alt="Discord" src="https://img.shields.io/badge/Discord-join%20community-5865F2?logo=discord&logoColor=white"></a>
   <a href="LICENSE"><img alt="License: MIT" src="https://img.shields.io/badge/License-MIT-111111.svg"></a>
   <a href="#quick-start"><img alt="Release: v0.1.0" src="https://img.shields.io/badge/Release-v0.1.0-0A7A53.svg"></a>
+  <a href="https://www.npmjs.com/package/computer-use-cache"><img alt="npm" src="https://img.shields.io/npm/v/computer-use-cache?color=CB3837&logo=npm&logoColor=white"></a>
+  <img alt="Node 18+" src="https://img.shields.io/badge/Node-18%2B-339933?logo=node.js&logoColor=white">
   <img alt="Python 3.11+" src="https://img.shields.io/badge/Python-3.11%2B-3776AB?logo=python&logoColor=white">
   <img alt="OpenAI compatible" src="https://img.shields.io/badge/OpenAI-compatible-111111?logo=openai&logoColor=white">
   <img alt="OpenRouter compatible" src="https://img.shields.io/badge/OpenRouter-compatible-6C47FF">
@@ -16,7 +18,7 @@
 </p>
 
 <p align="center">
-  Cache repeated model requests, reduce upstream spend, and keep your existing OpenAI SDK code.
+  Cache repeated model requests, reduce upstream spend, and keep your existing OpenAI SDK or agent code.
 </p>
 
 <p align="center">
@@ -45,13 +47,15 @@
 
 Computer-Use Cache is a lightweight primitive for making repeatable agent workflows cheap and reliable. Model calls are expensive when agents repeat the same planning, coding, and tool-use prompts. This server sits between your app and any OpenAI-compatible provider, forwards cache misses upstream, stores successful JSON responses in SQLite, and serves exact repeated requests from cache.
 
-It is intentionally small and provider-neutral. There is no app auth, billing, credits, realtime voice, product state, or custom model catalog logic.
+It is intentionally small and provider-neutral. There is no app auth, billing, credits, realtime voice, product state, or custom model catalog logic. Use the npm package for a zero-dependency local proxy, or use the Python server when you want the SQLite implementation.
 
 ## Features
 
 - Drop-in `baseURL` replacement for OpenAI-compatible clients.
+- `npx` CLI for agents: `computer-use-cache start`, `init`, `stats`, `clear`, and `env`.
+- Zero-dependency Node proxy packaged for npm.
 - Works with OpenRouter by default and OpenAI directly via `UPSTREAM_BASE_URL`.
-- SQLite-backed response cache with TTL, model allowlists, and denylists.
+- File-backed npm cache or SQLite-backed Python cache with TTL, model allowlists, and denylists.
 - Cache hit/miss headers on every response.
 - Streaming support for cache hits via Server-Sent Events.
 - Request-level cache bypass controls.
@@ -60,7 +64,55 @@ It is intentionally small and provider-neutral. There is no app auth, billing, c
 
 ## Quick Start
 
-npm CLI for agents: https://www.npmjs.com/package/computer-use-cache
+### NPM Agent Tool
+
+Run a local OpenAI-compatible cache in front of OpenRouter or OpenAI:
+
+```bash
+export UPSTREAM_BASE_URL=https://openrouter.ai/api/v1
+export UPSTREAM_API_KEY=sk-or-v1-your-key-here
+
+npx -y computer-use-cache start
+```
+
+Point any OpenAI-compatible agent or SDK at:
+
+```bash
+export OPENAI_BASE_URL=http://127.0.0.1:8000/v1
+export OPENAI_API_KEY=$UPSTREAM_API_KEY
+```
+
+Useful CLI commands:
+
+```bash
+npx -y computer-use-cache init
+npx -y computer-use-cache env
+npx -y computer-use-cache stats
+npx -y computer-use-cache clear
+npx -y computer-use-cache doctor
+```
+
+Install locally:
+
+```bash
+npm i computer-use-cache
+computer-use-cache start --port 8000
+```
+
+### Paste This Into Any Agent
+
+```text
+Use Computer-Use Cache as the OpenAI-compatible base URL for repeatable computer-use, browser, coding, and tool workflows.
+
+Base URL: http://127.0.0.1:8000/v1
+
+Keep deterministic parameters stable when replaying work: model, messages, tools, tool_choice, response_format, temperature, top_p, and seed.
+Use cache: false only for private, one-off, or credential-bearing requests.
+Never include API keys, passwords, private tokens, or credentials in cached prompts.
+Check X-Computer-Use-Cache: HIT, MISS, or BYPASS to understand savings.
+```
+
+### Python Server
 
 ```bash
 cd code-model-cache-server
@@ -81,6 +133,8 @@ Point any OpenAI-compatible client at:
 http://127.0.0.1:8000/v1
 ```
 
+The npm and Python servers expose the same OpenAI-compatible routes.
+
 ## OpenAI SDK Example
 
 ```js
@@ -100,6 +154,18 @@ const result = await client.chat.completions.create({
 });
 
 console.log(result.choices[0].message.content);
+```
+
+## JS SDK Helper
+
+```js
+import OpenAI from "openai";
+import { openAIConfig } from "computer-use-cache";
+
+const client = new OpenAI(openAIConfig({
+  baseURL: "http://127.0.0.1:8000/v1",
+  apiKey: process.env.UPSTREAM_API_KEY,
+}));
 ```
 
 If `UPSTREAM_API_KEY` is configured on the server, client API keys are ignored for upstream forwarding. If it is not configured, the server forwards the incoming `Authorization: Bearer ...` token upstream.
@@ -124,10 +190,12 @@ The first request is a cache miss and gets forwarded upstream. Repeat the exact 
 Cache status is returned in headers:
 
 ```text
-X-Code-Model-Cache: MISS
-X-Code-Model-Cache-Key: ...
-X-Code-Model-Cache-Store: stored
+X-Computer-Use-Cache: MISS
+X-Computer-Use-Cache-Key: ...
+X-Computer-Use-Cache-Store: stored
 ```
+
+The legacy `X-Code-Model-Cache` headers are also returned for compatibility.
 
 ## Routes
 
@@ -163,8 +231,9 @@ docker run --rm -p 8000:8000 \
 | `UPSTREAM_BASE_URL` | `https://openrouter.ai/api/v1` | Upstream OpenAI-compatible base URL. |
 | `UPSTREAM_API_KEY` | empty | Server-side upstream API key. Falls back to `OPENROUTER_API_KEY` or `OPENAI_API_KEY`. |
 | `UPSTREAM_TIMEOUT_SECONDS` | `180` | Upstream request timeout. |
-| `HOST` | `0.0.0.0` | Flask bind host for local runs. |
-| `PORT` | `8000` | Flask bind port for local runs. |
+| `HOST` | `127.0.0.1` for npm, `0.0.0.0` for Python | Bind host for local runs. |
+| `PORT` | `8000` | Bind port for local runs. |
+| `CACHE_DIR` | `./.computer-use-cache` | NPM package file cache directory. |
 | `CACHE_DB_PATH` | `./code_model_cache.sqlite3` | SQLite cache location. |
 | `CACHE_ENABLED` | `1` | Default cache behavior. Requests can override with `"cache": false`. |
 | `CACHE_TTL_SECONDS` | `2592000` | Cache entry TTL. Set `0` to disable expiry. |

--- a/bin/computer-use-cache.mjs
+++ b/bin/computer-use-cache.mjs
@@ -1,0 +1,176 @@
+#!/usr/bin/env node
+import { readFileSync } from 'node:fs';
+import { mkdir, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import process from 'node:process';
+import { createComputerUseCacheServer, configFromEnv } from '../src/server.mjs';
+
+const PACKAGE_JSON = JSON.parse(readFileSync(new URL('../package.json', import.meta.url), 'utf8'));
+const VERSION = PACKAGE_JSON.version || '0.0.0';
+
+function usage() {
+  return `Computer-Use Cache ${VERSION}
+
+OpenAI-compatible cache proxy for repeatable computer-use and agent workflows.
+
+Usage:
+  computer-use-cache start [--port 8000] [--host 127.0.0.1] [--upstream https://openrouter.ai/api/v1]
+  computer-use-cache init [--dir .]
+  computer-use-cache env [--port 8000]
+  computer-use-cache stats [--url http://127.0.0.1:8000]
+  computer-use-cache clear [--url http://127.0.0.1:8000] [--admin-token token]
+  computer-use-cache doctor
+
+Examples:
+  npx -y computer-use-cache start --upstream https://openrouter.ai/api/v1
+  export OPENAI_BASE_URL=http://127.0.0.1:8000/v1
+  export OPENAI_API_KEY=$OPENROUTER_API_KEY
+`;
+}
+
+function parseArgs(argv) {
+  const args = { _: [] };
+  for (let index = 0; index < argv.length; index += 1) {
+    const item = argv[index];
+    if (!item.startsWith('--')) {
+      args._.push(item);
+      continue;
+    }
+    const [rawKey, inline] = item.slice(2).split('=', 2);
+    const key = rawKey.replace(/-([a-z])/g, (_, char) => char.toUpperCase());
+    if (inline !== undefined) {
+      args[key] = inline;
+    } else if (argv[index + 1] && !argv[index + 1].startsWith('--')) {
+      args[key] = argv[index + 1];
+      index += 1;
+    } else {
+      args[key] = true;
+    }
+  }
+  return args;
+}
+
+function optionNumber(value, fallback) {
+  const parsed = Number.parseInt(String(value ?? ''), 10);
+  return Number.isFinite(parsed) ? parsed : fallback;
+}
+
+async function writeInitFiles(targetDir) {
+  await mkdir(targetDir, { recursive: true });
+  const envText = `# Computer-Use Cache
+UPSTREAM_BASE_URL=https://openrouter.ai/api/v1
+UPSTREAM_API_KEY=sk-or-v1-your-key
+HOST=127.0.0.1
+PORT=8000
+CACHE_DIR=.computer-use-cache
+CACHE_ENABLED=1
+CACHE_TTL_SECONDS=2592000
+INCLUDE_CACHE_METADATA=1
+`;
+  const promptText = `# Computer-Use Cache Agent Instructions
+
+Use Computer-Use Cache as the OpenAI-compatible base URL for repeatable computer-use, browser, coding, and tool workflows.
+
+Base URL:
+
+\`\`\`text
+http://127.0.0.1:8000/v1
+\`\`\`
+
+When you call an OpenAI-compatible model, keep deterministic parameters stable for repeatable work:
+
+- Keep model, messages, tools, tool_choice, response_format, temperature, top_p, and seed consistent when replaying a workflow.
+- Use \`cache: false\` only for private, one-off, or credential-bearing requests.
+- Do not include API keys, passwords, private tokens, or credentials in cached prompts.
+- Check response headers: \`X-Computer-Use-Cache: HIT|MISS|BYPASS\`.
+
+For Codex/OpenClaw/Hermes/Claude wrappers, set:
+
+\`\`\`bash
+export OPENAI_BASE_URL=http://127.0.0.1:8000/v1
+export OPENAI_API_KEY=$UPSTREAM_API_KEY
+\`\`\`
+`;
+  const configText = JSON.stringify({
+    baseURL: 'http://127.0.0.1:8000/v1',
+    cacheHeader: 'X-Computer-Use-Cache',
+    chatCompletionsEndpoint: '/v1/chat/completions',
+    statsEndpoint: '/cache/stats'
+  }, null, 2);
+  await writeFile(path.join(targetDir, '.env.computer-use-cache.example'), envText, 'utf8');
+  await writeFile(path.join(targetDir, 'COMPUTER_USE_CACHE_AGENT.md'), promptText, 'utf8');
+  await writeFile(path.join(targetDir, 'computer-use-cache.config.json'), `${configText}\n`, 'utf8');
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const command = args._[0] || (args.version ? 'version' : args.help ? 'help' : 'help');
+  if (command === 'help' || command === '--help' || command === '-h') {
+    console.log(usage());
+    return;
+  }
+  if (command === 'version' || command === '--version' || command === '-v') {
+    console.log(VERSION);
+    return;
+  }
+  if (command === 'init') {
+    const dir = path.resolve(String(args.dir || args.d || '.'));
+    await writeInitFiles(dir);
+    console.log(`Created Computer-Use Cache agent files in ${dir}`);
+    console.log('Next: npx -y computer-use-cache start');
+    return;
+  }
+  if (command === 'env') {
+    const host = args.host || '127.0.0.1';
+    const port = optionNumber(args.port, 8000);
+    console.log(`export OPENAI_BASE_URL=http://${host}:${port}/v1`);
+    console.log('export OPENAI_API_KEY=$UPSTREAM_API_KEY');
+    return;
+  }
+  if (command === 'doctor') {
+    console.log(`node: ${process.version}`);
+    console.log(`fetch: ${typeof fetch === 'function' ? 'ok' : 'missing'}`);
+    console.log(`upstream key: ${process.env.UPSTREAM_API_KEY || process.env.OPENROUTER_API_KEY || process.env.OPENAI_API_KEY ? 'set' : 'missing'}`);
+    console.log(`cache dir: ${configFromEnv(args).cacheDir}`);
+    return;
+  }
+  if (command === 'stats' || command === 'clear') {
+    const base = String(args.url || 'http://127.0.0.1:8000').replace(/\/+$/, '');
+    const headers = {};
+    if (args.adminToken) headers['x-cache-admin-token'] = String(args.adminToken);
+    const response = await fetch(`${base}${command === 'stats' ? '/cache/stats' : '/cache/clear'}`, {
+      method: command === 'stats' ? 'GET' : 'POST',
+      headers
+    });
+    const text = await response.text();
+    console.log(text);
+    if (!response.ok) process.exitCode = 1;
+    return;
+  }
+  if (command === 'start' || command === 'serve' || command === 'proxy') {
+    const overrides = {
+      host: args.host,
+      port: args.port,
+      upstreamBaseUrl: args.upstream || args.upstreamBaseUrl,
+      upstreamApiKey: args.upstreamApiKey,
+      cacheDir: args.cacheDir,
+      adminToken: args.adminToken
+    };
+    const server = createComputerUseCacheServer(overrides);
+    const config = server.computerUseCache.config;
+    await new Promise((resolve) => server.listen(config.port, config.host, resolve));
+    console.log(`Computer-Use Cache listening on http://${config.host}:${config.port}`);
+    console.log(`OpenAI-compatible baseURL: http://${config.host}:${config.port}/v1`);
+    console.log(`Upstream: ${config.upstreamBaseUrl}`);
+    console.log(`Cache dir: ${config.cacheDir}`);
+    return;
+  }
+  console.error(`Unknown command: ${command}\n`);
+  console.error(usage());
+  process.exitCode = 1;
+}
+
+main().catch((error) => {
+  console.error(error?.stack || error?.message || String(error));
+  process.exitCode = 1;
+});

--- a/package.json
+++ b/package.json
@@ -1,0 +1,60 @@
+{
+  "name": "computer-use-cache",
+  "version": "0.1.0",
+  "description": "OpenAI-compatible cache proxy and CLI that helps agents reduce repeated computer-use model costs.",
+  "type": "module",
+  "license": "MIT",
+  "author": "SuperPowers AI",
+  "homepage": "https://github.com/rohanarun/computer-use-cache#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/rohanarun/computer-use-cache.git"
+  },
+  "bugs": {
+    "url": "https://github.com/rohanarun/computer-use-cache/issues"
+  },
+  "keywords": [
+    "computer-use",
+    "cache",
+    "openai",
+    "openrouter",
+    "agents",
+    "llm",
+    "proxy",
+    "chat-completions",
+    "cost-savings"
+  ],
+  "bin": {
+    "computer-use-cache": "bin/computer-use-cache.mjs"
+  },
+  "exports": {
+    ".": "./src/client.mjs",
+    "./server": "./src/server.mjs"
+  },
+  "files": [
+    "bin/",
+    "src/",
+    "server.py",
+    "requirements.txt",
+    "Dockerfile",
+    ".env.example",
+    "README.md",
+    "LICENSE"
+  ],
+  "scripts": {
+    "start": "node bin/computer-use-cache.mjs start",
+    "test": "npm run test:smoke && npm run test:cli",
+    "test:smoke": "node test/smoke.mjs",
+    "test:cli": "node bin/computer-use-cache.mjs --version && node bin/computer-use-cache.mjs doctor",
+    "pack:check": "npm pack --dry-run --cache ./.npm-cache",
+    "publish:dry": "npm publish --dry-run --cache ./.npm-cache",
+    "publish:npm": "npm publish --cache ./.npm-cache",
+    "prepublishOnly": "npm test && npm run pack:check"
+  },
+  "engines": {
+    "node": ">=18.17"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/src/client.mjs
+++ b/src/client.mjs
@@ -1,0 +1,49 @@
+export function computerUseCacheBaseURL(options = {}) {
+  const host = options.host || '127.0.0.1';
+  const port = options.port || 8000;
+  const protocol = options.protocol || 'http';
+  return options.baseURL || `${protocol}://${host}:${port}/v1`;
+}
+
+export function openAIConfig(options = {}) {
+  return {
+    baseURL: computerUseCacheBaseURL(options),
+    apiKey: options.apiKey || process.env.OPENAI_API_KEY || process.env.UPSTREAM_API_KEY || 'computer-use-cache'
+  };
+}
+
+export function createComputerUseCacheClient(options = {}) {
+  const baseURL = String(options.baseURL || computerUseCacheBaseURL(options)).replace(/\/+$/, '');
+  const apiKey = options.apiKey || process.env.OPENAI_API_KEY || process.env.UPSTREAM_API_KEY || 'computer-use-cache';
+  const fetchImpl = options.fetch || globalThis.fetch;
+  if (typeof fetchImpl !== 'function') {
+    throw new Error('A fetch implementation is required.');
+  }
+  async function request(path, body) {
+    const response = await fetchImpl(`${baseURL}${path}`, {
+      method: 'POST',
+      headers: {
+        authorization: `Bearer ${apiKey}`,
+        'content-type': 'application/json'
+      },
+      body: JSON.stringify(body || {})
+    });
+    const data = await response.json().catch(() => ({}));
+    if (!response.ok) {
+      const message = data?.error?.message || data?.message || `Request failed with ${response.status}`;
+      throw new Error(message);
+    }
+    return data;
+  }
+  return {
+    baseURL,
+    chat: {
+      completions: {
+        create: (body) => request('/chat/completions', body)
+      }
+    },
+    completions: {
+      create: (body) => request('/completions', body)
+    }
+  };
+}

--- a/src/server.mjs
+++ b/src/server.mjs
@@ -1,0 +1,561 @@
+import http from 'node:http';
+import { createHash, randomUUID } from 'node:crypto';
+import { mkdir, readdir, readFile, rm, stat, writeFile } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const FALSE_VALUES = new Set(['0', 'false', 'no', 'off']);
+const TRUE_VALUES = new Set(['1', 'true', 'yes', 'on']);
+const CACHE_CONTROL_KEYS = new Set(['stream', 'cache', 'cache_control']);
+const DEFAULT_CACHE_IGNORE_KEYS = new Set(['metadata']);
+const SENSITIVE_PATTERN = /(?:api[_-]?key|secret|password|passwd|access[_-]?token|refresh[_-]?token|private[_-]?key)\s*[:=]\s*['"]?[^'"\s]{8,}/i;
+
+function boolFromValue(value, fallback = false) {
+  if (typeof value === 'boolean') return value;
+  if (value === undefined || value === null || value === '') return fallback;
+  const normalized = String(value).trim().toLowerCase();
+  if (TRUE_VALUES.has(normalized)) return true;
+  if (FALSE_VALUES.has(normalized)) return false;
+  return fallback;
+}
+
+function intFromValue(value, fallback) {
+  const parsed = Number.parseInt(String(value ?? ''), 10);
+  return Number.isFinite(parsed) ? parsed : fallback;
+}
+
+function floatFromValue(value, fallback) {
+  const parsed = Number.parseFloat(String(value ?? ''));
+  return Number.isFinite(parsed) ? parsed : fallback;
+}
+
+function listFromValue(value) {
+  return String(value || '')
+    .split(',')
+    .map((item) => item.trim())
+    .filter(Boolean);
+}
+
+function globToRegExp(glob) {
+  const escaped = String(glob || '').replace(/[.+^${}()|[\]\\]/g, '\\$&');
+  return new RegExp(`^${escaped.replace(/\*/g, '.*').replace(/\?/g, '.')}$`);
+}
+
+function matchesAny(value, patterns) {
+  if (!patterns.length) return false;
+  return patterns.some((pattern) => globToRegExp(pattern).test(String(value || '').trim()));
+}
+
+function compactJson(value) {
+  return JSON.stringify(value);
+}
+
+function stableNormalize(value, stringLimit) {
+  if (value === null || ['boolean', 'number'].includes(typeof value)) return value;
+  if (typeof value === 'string') return value.length > stringLimit ? value.slice(0, stringLimit) : value;
+  if (Array.isArray(value)) return value.map((item) => stableNormalize(item, stringLimit));
+  if (typeof value === 'object') {
+    const output = {};
+    for (const key of Object.keys(value).sort()) {
+      output[String(key)] = stableNormalize(value[key], stringLimit);
+    }
+    return output;
+  }
+  return String(value);
+}
+
+function cloneJson(value) {
+  return JSON.parse(JSON.stringify(value));
+}
+
+function safeHeaderValue(value) {
+  return String(value || '').replace(/[\r\n]/g, ' ').slice(0, 1024);
+}
+
+function responseHeaders(extra = {}) {
+  return {
+    'access-control-allow-origin': process.env.CORS_ALLOW_ORIGIN || '*',
+    'access-control-allow-methods': 'GET, POST, OPTIONS',
+    'access-control-allow-headers': 'Authorization, Content-Type, X-Cache-Bypass, X-Cache-Admin-Token',
+    ...extra
+  };
+}
+
+function sendJson(res, status, payload, headers = {}) {
+  const body = JSON.stringify(payload);
+  res.writeHead(status, responseHeaders({
+    'content-type': 'application/json; charset=utf-8',
+    'content-length': Buffer.byteLength(body),
+    ...headers
+  }));
+  res.end(body);
+}
+
+function openAiError(message, status = 400, type = 'invalid_request_error', code = null) {
+  return {
+    status,
+    body: {
+      error: {
+        message,
+        type,
+        param: null,
+        code
+      }
+    }
+  };
+}
+
+async function readRequestBody(req, maxBytes) {
+  const chunks = [];
+  let total = 0;
+  for await (const chunk of req) {
+    total += chunk.length;
+    if (total > maxBytes) {
+      throw Object.assign(new Error('Request body is too large.'), { status: 413 });
+    }
+    chunks.push(chunk);
+  }
+  return Buffer.concat(chunks).toString('utf8');
+}
+
+function bearerFromHeaders(headers) {
+  const value = headers.authorization || headers.Authorization || '';
+  const text = Array.isArray(value) ? value[0] : value;
+  return String(text || '').toLowerCase().startsWith('bearer ') ? String(text).slice(7).trim() : '';
+}
+
+function upstreamHeaders(req, config) {
+  const token = config.upstreamApiKey || bearerFromHeaders(req.headers);
+  const headers = {
+    accept: 'application/json',
+    'content-type': 'application/json'
+  };
+  if (token) headers.authorization = `Bearer ${token}`;
+  const referer = process.env.OPENROUTER_HTTP_REFERER || req.headers['http-referer'];
+  const title = process.env.OPENROUTER_X_TITLE || req.headers['x-title'];
+  if (referer) headers['HTTP-Referer'] = String(referer);
+  if (title) headers['X-Title'] = String(title);
+  return headers;
+}
+
+function requestCacheEnabled(data, fallback) {
+  if (Object.prototype.hasOwnProperty.call(data, 'cache')) return boolFromValue(data.cache, fallback);
+  if (data.cache_control && typeof data.cache_control === 'object' && Object.prototype.hasOwnProperty.call(data.cache_control, 'enabled')) {
+    return boolFromValue(data.cache_control.enabled, fallback);
+  }
+  if (data.metadata && typeof data.metadata === 'object') {
+    if (Object.prototype.hasOwnProperty.call(data.metadata, 'cache')) return boolFromValue(data.metadata.cache, fallback);
+    if (Object.prototype.hasOwnProperty.call(data.metadata, 'cache_enabled')) return boolFromValue(data.metadata.cache_enabled, fallback);
+  }
+  return fallback;
+}
+
+function normalizedCacheInput(data, mode, config) {
+  if (!data || typeof data !== 'object' || Array.isArray(data)) return { reason: 'request body must be an object' };
+  const model = String(data.model || '').trim();
+  if (!model) return { reason: 'model is required' };
+  if (matchesAny(model, config.modelDenylist)) return { reason: `model is not cacheable: ${model}` };
+  if (config.modelAllowlist.length && !matchesAny(model, config.modelAllowlist)) return { reason: `model is not cacheable: ${model}` };
+
+  const ignored = new Set([...CACHE_CONTROL_KEYS, ...config.cacheIgnoreKeys]);
+  const payload = { mode };
+  for (const key of Object.keys(data).sort()) {
+    if (ignored.has(String(key))) continue;
+    payload[String(key)] = stableNormalize(data[key], config.maxInputChars);
+  }
+  const json = compactJson(payload);
+  if (json.length > config.maxInputChars) return { reason: 'request is too large for cache' };
+  if (SENSITIVE_PATTERN.test(json)) return { reason: 'request appears to contain credentials or secrets' };
+  const cacheKey = createHash('sha256').update(json).digest('hex');
+  return { cacheKey, requestPayload: { ...payload, cache_key: cacheKey } };
+}
+
+function completionText(payload) {
+  const choices = Array.isArray(payload?.choices) ? payload.choices : [];
+  const first = choices[0] && typeof choices[0] === 'object' ? choices[0] : {};
+  if (typeof first.text === 'string') return first.text;
+  const message = first.message && typeof first.message === 'object' ? first.message : {};
+  const content = message.content;
+  if (typeof content === 'string') return content;
+  if (Array.isArray(content)) {
+    return content.map((part) => {
+      if (part && typeof part === 'object') return part.text || part.content || '';
+      return '';
+    }).join('');
+  }
+  return '';
+}
+
+function withCacheMetadata(payload, config, cacheHit, cacheKey, storeStatus = '', bypassReason = '') {
+  const cloned = cloneJson(payload);
+  if (config.includeCacheMetadata && cloned && typeof cloned === 'object') {
+    cloned.computer_use_cache = {
+      cache_hit: Boolean(cacheHit),
+      cache_key: cacheKey || null,
+      store_status: storeStatus || null,
+      bypass_reason: bypassReason || null
+    };
+  }
+  return cloned;
+}
+
+function cacheHeaders(status, cacheKey, storeStatus = '', reason = '') {
+  return {
+    'x-computer-use-cache': status,
+    'x-computer-use-cache-key': cacheKey || '',
+    'x-computer-use-cache-store': storeStatus || '',
+    'x-computer-use-cache-reason': reason || '',
+    'x-code-model-cache': status,
+    'x-code-model-cache-key': cacheKey || '',
+    'x-code-model-cache-store': storeStatus || ''
+  };
+}
+
+function sse(payload) {
+  return `data: ${JSON.stringify(payload)}\n\n`;
+}
+
+function cachedStreamChunks(payload, mode) {
+  const id = String(payload.id || `chatcmpl-cache-${randomUUID().replace(/-/g, '').slice(0, 16)}`);
+  const created = Number(payload.created || Math.floor(Date.now() / 1000));
+  const model = String(payload.model || '');
+  const text = completionText(payload);
+  const first = Array.isArray(payload.choices) && payload.choices[0] && typeof payload.choices[0] === 'object' ? payload.choices[0] : {};
+  const finishReason = first.finish_reason || 'stop';
+  if (mode === 'completion') {
+    return [
+      sse({ id, object: 'text_completion', created, model, choices: [{ index: 0, text, finish_reason: null }] }),
+      sse({ id, object: 'text_completion', created, model, choices: [{ index: 0, text: '', finish_reason: finishReason }] }),
+      'data: [DONE]\n\n'
+    ];
+  }
+  return [
+    sse({ id, object: 'chat.completion.chunk', created, model, choices: [{ index: 0, delta: { role: 'assistant', content: text }, finish_reason: null }] }),
+    sse({ id, object: 'chat.completion.chunk', created, model, choices: [{ index: 0, delta: {}, finish_reason: finishReason }] }),
+    'data: [DONE]\n\n'
+  ];
+}
+
+class FileCompletionCache {
+  constructor(config) {
+    this.config = config;
+    this.entriesDir = path.join(config.cacheDir, 'entries');
+  }
+
+  async ensure() {
+    await mkdir(this.entriesDir, { recursive: true });
+  }
+
+  entryPath(cacheKey) {
+    return path.join(this.entriesDir, `${cacheKey}.json`);
+  }
+
+  async lookup(cacheKey) {
+    if (!cacheKey) return null;
+    await this.ensure();
+    const target = this.entryPath(cacheKey);
+    try {
+      const raw = await readFile(target, 'utf8');
+      const entry = JSON.parse(raw);
+      const now = Date.now() / 1000;
+      if (this.config.ttlSeconds > 0 && now - Number(entry.created_at || 0) > this.config.ttlSeconds) {
+        await rm(target, { force: true });
+        return null;
+      }
+      entry.hits = Number(entry.hits || 0) + 1;
+      entry.last_hit_at = now;
+      await writeFile(target, JSON.stringify(entry), 'utf8');
+      return entry;
+    } catch {
+      return null;
+    }
+  }
+
+  async store(cacheKey, mode, requestPayload, responsePayload) {
+    if (!responsePayload || typeof responsePayload !== 'object' || Array.isArray(responsePayload)) return 'skipped: response is not a JSON object';
+    const cloned = cloneJson(responsePayload);
+    delete cloned.computer_use_cache;
+    delete cloned.code_model_cache;
+    const responseJson = compactJson(cloned);
+    if (responseJson.length > this.config.maxResponseChars) return 'skipped: response is too large for cache';
+    await this.ensure();
+    const now = Date.now() / 1000;
+    const target = this.entryPath(cacheKey);
+    let previous = {};
+    try {
+      previous = JSON.parse(await readFile(target, 'utf8'));
+    } catch {
+      previous = {};
+    }
+    const entry = {
+      cache_key: cacheKey,
+      mode,
+      model: String(requestPayload.model || cloned.model || ''),
+      request: requestPayload,
+      response: cloned,
+      created_at: Number(previous.created_at || now),
+      updated_at: now,
+      last_hit_at: previous.last_hit_at || null,
+      hits: Number(previous.hits || 0)
+    };
+    await writeFile(target, JSON.stringify(entry), 'utf8');
+    return previous.cache_key ? 'updated' : 'stored';
+  }
+
+  async stats() {
+    await this.ensure();
+    const files = await readdir(this.entriesDir).catch(() => []);
+    let hits = 0;
+    let lastUpdated = null;
+    let bytes = 0;
+    for (const file of files) {
+      if (!file.endsWith('.json')) continue;
+      const target = path.join(this.entriesDir, file);
+      try {
+        const info = await stat(target);
+        bytes += info.size;
+        const entry = JSON.parse(await readFile(target, 'utf8'));
+        hits += Number(entry.hits || 0);
+        const updated = Number(entry.updated_at || 0);
+        if (updated && (!lastUpdated || updated > lastUpdated)) lastUpdated = updated;
+      } catch {
+        // Ignore corrupt cache entries. They can be deleted with cache clear.
+      }
+    }
+    return {
+      entries: files.filter((file) => file.endsWith('.json')).length,
+      hits,
+      last_updated_at: lastUpdated,
+      cache_dir: this.config.cacheDir,
+      ttl_seconds: this.config.ttlSeconds,
+      bytes
+    };
+  }
+
+  async clear() {
+    await this.ensure();
+    const files = await readdir(this.entriesDir).catch(() => []);
+    let deleted = 0;
+    for (const file of files) {
+      if (!file.endsWith('.json')) continue;
+      await rm(path.join(this.entriesDir, file), { force: true });
+      deleted += 1;
+    }
+    return deleted;
+  }
+}
+
+function defaultCacheDir() {
+  return path.join(process.cwd(), '.computer-use-cache');
+}
+
+export function configFromEnv(overrides = {}) {
+  const ignoreKeys = new Set(DEFAULT_CACHE_IGNORE_KEYS);
+  for (const key of listFromValue(overrides.cacheIgnoreKeys ?? process.env.CACHE_IGNORE_KEYS)) ignoreKeys.add(key);
+  return {
+    host: String(overrides.host ?? process.env.HOST ?? '127.0.0.1'),
+    port: intFromValue(overrides.port ?? process.env.PORT, 8000),
+    upstreamBaseUrl: String(overrides.upstreamBaseUrl ?? process.env.UPSTREAM_BASE_URL ?? process.env.OPENAI_BASE_URL ?? 'https://openrouter.ai/api/v1').replace(/\/+$/, ''),
+    upstreamApiKey: String(overrides.upstreamApiKey ?? process.env.UPSTREAM_API_KEY ?? process.env.OPENROUTER_API_KEY ?? process.env.OPENAI_API_KEY ?? '').trim(),
+    upstreamTimeoutMs: Math.max(1000, Math.floor(floatFromValue(overrides.upstreamTimeoutSeconds ?? process.env.UPSTREAM_TIMEOUT_SECONDS, 180) * 1000)),
+    cacheDir: String(overrides.cacheDir ?? process.env.CACHE_DIR ?? process.env.COMPUTER_USE_CACHE_DIR ?? defaultCacheDir()),
+    cacheEnabled: boolFromValue(overrides.cacheEnabled ?? process.env.CACHE_ENABLED, true),
+    ttlSeconds: intFromValue(overrides.ttlSeconds ?? process.env.CACHE_TTL_SECONDS, 60 * 60 * 24 * 30),
+    maxInputChars: intFromValue(overrides.maxInputChars ?? process.env.CACHE_MAX_INPUT_CHARS, 120000),
+    maxResponseChars: intFromValue(overrides.maxResponseChars ?? process.env.CACHE_MAX_RESPONSE_CHARS, 240000),
+    maxBodyBytes: intFromValue(overrides.maxBodyBytes ?? process.env.MAX_BODY_BYTES, 2 * 1024 * 1024),
+    modelAllowlist: listFromValue(overrides.modelAllowlist ?? process.env.CACHE_MODEL_ALLOWLIST),
+    modelDenylist: listFromValue(overrides.modelDenylist ?? process.env.CACHE_MODEL_DENYLIST),
+    cacheIgnoreKeys: ignoreKeys,
+    includeCacheMetadata: boolFromValue(overrides.includeCacheMetadata ?? process.env.INCLUDE_CACHE_METADATA, false),
+    adminToken: String(overrides.adminToken ?? process.env.CACHE_ADMIN_TOKEN ?? '').trim()
+  };
+}
+
+async function proxyJson(req, res, config, cache, routePath, mode) {
+  let data;
+  try {
+    const body = await readRequestBody(req, config.maxBodyBytes);
+    data = body ? JSON.parse(body) : {};
+  } catch (error) {
+    const status = error.status || 400;
+    const payload = openAiError(error.message || 'Invalid JSON request body.', status).body;
+    sendJson(res, status, payload);
+    return;
+  }
+
+  const wantsStream = Boolean(data.stream);
+  const bypassHeader = boolFromValue(req.headers['x-cache-bypass'], false);
+  const cacheEnabled = config.cacheEnabled && requestCacheEnabled(data, true) && !bypassHeader;
+  let cacheKey = '';
+  let requestPayload = null;
+  let bypassReason = '';
+
+  if (cacheEnabled) {
+    const normalized = normalizedCacheInput(data, mode, config);
+    if (normalized.cacheKey) {
+      cacheKey = normalized.cacheKey;
+      requestPayload = normalized.requestPayload;
+      const hit = await cache.lookup(cacheKey);
+      if (hit?.response) {
+        if (wantsStream) {
+          res.writeHead(200, responseHeaders({
+            'content-type': 'text/event-stream; charset=utf-8',
+            'cache-control': 'no-cache',
+            ...cacheHeaders('HIT', cacheKey)
+          }));
+          for (const chunk of cachedStreamChunks(hit.response, mode)) res.write(chunk);
+          res.end();
+          return;
+        }
+        sendJson(res, 200, withCacheMetadata(hit.response, config, true, cacheKey), cacheHeaders('HIT', cacheKey));
+        return;
+      }
+    } else {
+      bypassReason = normalized.reason || 'not cacheable';
+    }
+  } else {
+    bypassReason = bypassHeader ? 'X-Cache-Bypass' : 'cache disabled';
+  }
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), config.upstreamTimeoutMs);
+  let upstream;
+  try {
+    upstream = await fetch(`${config.upstreamBaseUrl}${routePath}`, {
+      method: 'POST',
+      headers: upstreamHeaders(req, config),
+      body: JSON.stringify(data),
+      signal: controller.signal
+    });
+  } catch (error) {
+    clearTimeout(timer);
+    sendJson(res, 502, openAiError(`Upstream request failed: ${error.message}`, 502, 'upstream_error', 'upstream_failed').body, cacheHeaders('BYPASS', cacheKey, '', bypassReason));
+    return;
+  }
+  clearTimeout(timer);
+
+  if (wantsStream) {
+    res.writeHead(upstream.status, responseHeaders({
+      'content-type': upstream.headers.get('content-type') || 'text/event-stream; charset=utf-8',
+      ...cacheHeaders(cacheKey ? 'MISS' : 'BYPASS', cacheKey, 'stream-not-stored', bypassReason)
+    }));
+    if (upstream.body) {
+      for await (const chunk of upstream.body) res.write(Buffer.from(chunk));
+    }
+    res.end();
+    return;
+  }
+
+  const text = await upstream.text();
+  let payload;
+  try {
+    payload = JSON.parse(text);
+  } catch {
+    res.writeHead(upstream.status, responseHeaders({
+      'content-type': upstream.headers.get('content-type') || 'text/plain; charset=utf-8',
+      ...cacheHeaders('BYPASS', cacheKey, '', 'upstream returned non-json')
+    }));
+    res.end(text);
+    return;
+  }
+
+  let storeStatus = '';
+  if (upstream.ok && cacheKey && requestPayload && payload && typeof payload === 'object' && !Array.isArray(payload)) {
+    storeStatus = await cache.store(cacheKey, mode, requestPayload, payload);
+  }
+  const status = cacheKey ? 'MISS' : 'BYPASS';
+  sendJson(res, upstream.status, withCacheMetadata(payload, config, false, cacheKey, storeStatus, bypassReason), cacheHeaders(status, cacheKey, storeStatus, bypassReason));
+}
+
+async function proxyModels(req, res, config) {
+  try {
+    const upstream = await fetch(`${config.upstreamBaseUrl}/models`, {
+      method: 'GET',
+      headers: upstreamHeaders(req, config)
+    });
+    const contentType = upstream.headers.get('content-type') || 'application/json; charset=utf-8';
+    const text = await upstream.text();
+    res.writeHead(upstream.status, responseHeaders({ 'content-type': contentType }));
+    res.end(text);
+  } catch (error) {
+    sendJson(res, 502, openAiError(`Upstream models request failed: ${error.message}`, 502, 'upstream_error', 'upstream_failed').body);
+  }
+}
+
+function requireAdmin(req, res, config) {
+  if (!config.adminToken) return true;
+  const provided = String(req.headers['x-cache-admin-token'] || '').trim() || bearerFromHeaders(req.headers);
+  if (provided === config.adminToken) return true;
+  sendJson(res, 401, openAiError('Invalid cache admin token.', 401, 'authentication_error', 'invalid_api_key').body);
+  return false;
+}
+
+export function createComputerUseCacheServer(overrides = {}) {
+  const config = configFromEnv(overrides);
+  const cache = overrides.cache || new FileCompletionCache(config);
+  const server = http.createServer(async (req, res) => {
+    try {
+      const parsed = new URL(req.url || '/', `http://${req.headers.host || 'localhost'}`);
+      const pathname = parsed.pathname.replace(/\/+$/, '') || '/';
+      if (req.method === 'OPTIONS') {
+        res.writeHead(204, responseHeaders());
+        res.end();
+        return;
+      }
+      if (req.method === 'GET' && pathname === '/') {
+        sendJson(res, 200, {
+          name: 'computer-use-cache',
+          status: 'ok',
+          upstream_base_url: config.upstreamBaseUrl,
+          endpoints: ['/v1/chat/completions', '/chat/completions', '/v1/completions', '/v1/models', '/cache/stats']
+        });
+        return;
+      }
+      if (req.method === 'GET' && pathname === '/healthz') {
+        sendJson(res, 200, { ok: true, cache: await cache.stats(), upstream_base_url: config.upstreamBaseUrl });
+        return;
+      }
+      if (req.method === 'GET' && (pathname === '/cache/stats' || pathname === '/stats')) {
+        sendJson(res, 200, await cache.stats());
+        return;
+      }
+      if (req.method === 'POST' && pathname === '/cache/clear') {
+        if (!requireAdmin(req, res, config)) return;
+        sendJson(res, 200, { ok: true, deleted: await cache.clear() });
+        return;
+      }
+      if (req.method === 'GET' && (pathname === '/v1/models' || pathname === '/models')) {
+        await proxyModels(req, res, config);
+        return;
+      }
+      const chatRoutes = new Set(['/v1/chat/completions', '/chat/completions', '/api/v1/chat/completions', '/api/chat/completions']);
+      const completionRoutes = new Set(['/v1/completions', '/completions', '/api/v1/completions', '/api/completions']);
+      if (req.method === 'POST' && chatRoutes.has(pathname)) {
+        await proxyJson(req, res, config, cache, '/chat/completions', 'chat');
+        return;
+      }
+      if (req.method === 'POST' && completionRoutes.has(pathname)) {
+        await proxyJson(req, res, config, cache, '/completions', 'completion');
+        return;
+      }
+      sendJson(res, 404, { error: 'not_found', message: `No route for ${req.method} ${pathname}` });
+    } catch (error) {
+      sendJson(res, 500, openAiError(error.message || 'Internal server error.', 500, 'server_error', 'internal_error').body);
+    }
+  });
+  server.computerUseCache = { config, cache };
+  return server;
+}
+
+export async function listen(overrides = {}) {
+  const server = createComputerUseCacheServer(overrides);
+  const config = server.computerUseCache.config;
+  await new Promise((resolve) => server.listen(config.port, config.host, resolve));
+  return server;
+}
+
+export function packageRoot() {
+  return path.dirname(path.dirname(fileURLToPath(import.meta.url)));
+}

--- a/test/smoke.mjs
+++ b/test/smoke.mjs
@@ -1,0 +1,59 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { createComputerUseCacheServer } from '../src/server.mjs';
+import {
+  computerUseCacheBaseURL,
+  createComputerUseCacheClient,
+  openAIConfig
+} from '../src/client.mjs';
+
+const cacheDir = await mkdtemp(path.join(tmpdir(), 'computer-use-cache-'));
+const server = createComputerUseCacheServer({
+  host: '127.0.0.1',
+  port: 0,
+  cacheDir,
+  adminToken: 'test-admin-token'
+});
+
+try {
+  await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const { port } = server.address();
+  const baseURL = `http://127.0.0.1:${port}`;
+
+  assert.equal(computerUseCacheBaseURL({ port }), `${baseURL}/v1`);
+  assert.deepEqual(openAIConfig({ port, apiKey: 'test-key' }), {
+    baseURL: `${baseURL}/v1`,
+    apiKey: 'test-key'
+  });
+
+  const root = await fetch(`${baseURL}/`).then((response) => response.json());
+  assert.equal(root.name, 'computer-use-cache');
+  assert.equal(root.status, 'ok');
+  assert.ok(root.endpoints.includes('/v1/chat/completions'));
+
+  const health = await fetch(`${baseURL}/healthz`).then((response) => response.json());
+  assert.equal(health.ok, true);
+  assert.equal(health.cache.entries, 0);
+
+  const stats = await fetch(`${baseURL}/cache/stats`).then((response) => response.json());
+  assert.equal(stats.entries, 0);
+  assert.equal(stats.cache_dir, cacheDir);
+
+  const unauthorizedClear = await fetch(`${baseURL}/cache/clear`, { method: 'POST' });
+  assert.equal(unauthorizedClear.status, 401);
+
+  const clear = await fetch(`${baseURL}/cache/clear`, {
+    method: 'POST',
+    headers: { 'x-cache-admin-token': 'test-admin-token' }
+  }).then((response) => response.json());
+  assert.equal(clear.ok, true);
+  assert.equal(clear.deleted, 0);
+
+  const client = createComputerUseCacheClient({ baseURL: `${baseURL}/v1`, apiKey: 'test-key' });
+  assert.equal(client.baseURL, `${baseURL}/v1`);
+} finally {
+  await new Promise((resolve) => server.close(resolve));
+  await rm(cacheDir, { recursive: true, force: true });
+}


### PR DESCRIPTION
## What changed

This PR updates `rohanarun/computer-use-cache` to include the published npm package source for `computer-use-cache@0.1.0`:

- Adds the zero-dependency Node CLI at `bin/computer-use-cache.mjs`
- Adds the file-backed OpenAI-compatible cache proxy in `src/server.mjs`
- Adds the JS helper client in `src/client.mjs`
- Adds npm package metadata, `.env.example`, and `.gitignore`
- Updates the README with npm install / `npx` usage, agent prompt instructions, JS helper docs, and cache headers
- Adds `test/smoke.mjs` so `npm test` works from the GitHub source checkout

## Why

The npm package already exists, but the GitHub repo still had the older Python-only shape. This makes GitHub match the published npm package and gives contributors a working test path.

## Validation

- `npm --cache "$PWD/../npm-cache" test`
- `npm --cache "$PWD/../npm-cache" run pack:check`
- Prior live Daytona validation: 1000/1000 ephemeral Daytona sandbox installs and runtime checks passed for `npx -y computer-use-cache`
